### PR TITLE
feat: added packagist.yml to automatically sync with packagist when a new release has passed

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,2 +1,3 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+.github/workflows/packagist.yml

--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -1,0 +1,21 @@
+name: Sync with Packagist
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  sync-packagist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync with Packagist
+        run: |
+          # Send webhook to Packagist to trigger package sync
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: push" \
+            -H "X-Packagist-Token: ${{ secrets.PACKAGIST_TOKEN }}" \
+            -d '{"ref": "refs/tags/${{ github.event.release.tag_name }}", "repository": {"full_name": "${{ github.repository }}"}}' \
+            "https://packagist.org/api/github?username=ittybit"
+        
+


### PR DESCRIPTION
This pull request adds automation to keep the Packagist package in sync with GitHub releases. The main change is the introduction of a new GitHub Actions workflow that triggers on release events and notifies Packagist to update the package.

**Continuous Integration / Release Automation:**

* Added `.github/workflows/packagist.yml` workflow to automatically sync the package with Packagist when a release is published or edited.
* Updated `.fernignore` to exclude the new workflow file from Fern modifications.